### PR TITLE
Pass attribute name to attribute hydrator closure

### DIFF
--- a/src/JsonApi/Hydrator/HydratorTrait.php
+++ b/src/JsonApi/Hydrator/HydratorTrait.php
@@ -95,7 +95,7 @@ trait HydratorTrait
                 continue;
             }
 
-            $result = $hydrator($domainObject, $data["attributes"][$attribute], $data);
+            $result = $hydrator($domainObject, $data["attributes"][$attribute], $data, $attribute);
             if ($result) {
                 $domainObject = $result;
             }


### PR DESCRIPTION
For the shake of consistency with passing the attribute name to attribute transformer closure in AbstractResourceTransformer (see #8).
