### PR TITLE
Avoid double stream reading

### DIFF
--- a/src/JsonApi/Request/Request.php
+++ b/src/JsonApi/Request/Request.php
@@ -769,9 +769,10 @@ class Request implements RequestInterface
      */
     public function getParsedBody()
     {
-        if ($this->serverRequest->getBody()->getContents() && empty($this->serverRequest->getParsedBody())) {
+        $content = $this->serverRequest->getBody()->getContents();
+        if ($content && empty($this->serverRequest->getParsedBody())) {
             $this->serverRequest = $this->serverRequest->withParsedBody(
-                json_decode($this->serverRequest->getBody(), true)
+                json_decode($content, true)
             );
         }
 


### PR DESCRIPTION
Hi,

With  colleague who is developping a [symfony bundle](https://github.com/qpautrat/woohoolabs-yin-bundle) to wrap your lib, we encounter a problem with the input stream reading in php5.5. In the php doc, it is said that we can't seek the input stream under php5.6 (refer to the note paragraph about ["php://input"](http://php.net/manual/en/wrappers.php.php)). So we propose to read only once the stream, it's also better for performance. For information we try to use it with [zend diactoros](https://github.com/zendframework/zend-diactoros), like recommended. 
