### PR TITLE
Relationships with empty data, issue #20

### DIFF
--- a/src/JsonApi/Schema/Relationship/AbstractRelationship.php
+++ b/src/JsonApi/Schema/Relationship/AbstractRelationship.php
@@ -125,7 +125,7 @@ abstract class AbstractRelationship
         ) {
             $transformedData = $this->transformData($transformation, $relationshipName, $defaultRelationships);
         } else {
-            $transformedData = null;
+            $transformedData = false;
         }
 
         if ($transformation->request->isIncludedField($resourceType, $relationshipName)) {
@@ -143,7 +143,7 @@ abstract class AbstractRelationship
             }
 
             // DATA
-            if (isset($transformedData) === true) {
+            if ($transformedData !== false) {
                 $relationship["data"] = $transformedData;
             }
         }

--- a/src/JsonApi/Schema/Relationship/ToManyRelationship.php
+++ b/src/JsonApi/Schema/Relationship/ToManyRelationship.php
@@ -34,7 +34,7 @@ class ToManyRelationship extends AbstractRelationship
     ) {
         $data = $this->retrieveData();
         if (empty($data) || $this->resourceTransformer === null) {
-            return null;
+            return [];
         }
 
         $content = [];


### PR DESCRIPTION
- When `transformData` returns an empty data-set (null or and empty array) include this in the response.
- The empty data for a ToManyRelationship is [] not null.

Referenced in issue #20 

`$transformedData` was set to null when it was not being included. Via the `isset()` function null values where not included in the response. Null is a valid response, for empty relationships.
