### PR TITLE
Add support for clearing relationships

### DIFF
--- a/src/JsonApi/Hydrator/HydratorTrait.php
+++ b/src/JsonApi/Hydrator/HydratorTrait.php
@@ -220,11 +220,14 @@ trait HydratorTrait
      */
     private function createRelationship(array $relationship)
     {
-        if (isset($relationship["data"]) === false) {
+        if (array_key_exists("data", $relationship) === false) {
             return null;
         }
 
-        if ($this->isAssociativeArray($relationship["data"]) === true) {
+        //If this is a request to clear the relationship, we create an empty relationship
+        if (is_null($relationship["data"])) {
+            $result = new ToOneRelationship();
+        } elseif ($this->isAssociativeArray($relationship["data"]) === true) {
             $result = new ToOneRelationship(ResourceIdentifier::fromArray($relationship["data"]));
         } else {
             $result = new ToManyRelationship();

--- a/src/JsonApi/Hydrator/Relationship/ToManyRelationship.php
+++ b/src/JsonApi/Hydrator/Relationship/ToManyRelationship.php
@@ -65,4 +65,14 @@ class ToManyRelationship
 
         return $ids;
     }
+
+    /**
+     * Returns true if this relationship is empty, not containing a resource identifier
+     * This will be the case when the request want to clear a relationship and sends an empty array as data.
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return empty($this->resourceIdentifiers);
+    }
 }

--- a/src/JsonApi/Hydrator/Relationship/ToOneRelationship.php
+++ b/src/JsonApi/Hydrator/Relationship/ToOneRelationship.php
@@ -6,7 +6,7 @@ use WoohooLabs\Yin\JsonApi\Schema\ResourceIdentifier;
 class ToOneRelationship
 {
     /**
-     * @var \WoohooLabs\Yin\JsonApi\Schema\ResourceIdentifier
+     * @var null | \WoohooLabs\Yin\JsonApi\Schema\ResourceIdentifier
      */
     protected $resourceIdentifier;
 
@@ -29,10 +29,20 @@ class ToOneRelationship
     }
 
     /**
-     * @return \WoohooLabs\Yin\JsonApi\Schema\ResourceIdentifier $resourceIdentifier
+     * @return null | \WoohooLabs\Yin\JsonApi\Schema\ResourceIdentifier $resourceIdentifier
      */
     public function getResourceIdentifier()
     {
         return $this->resourceIdentifier;
+    }
+
+    /**
+     * Returns true if this relationship is empty, not containing a resource identifier
+     * This will be the case when the request want to clear a relationship and sends null as data.
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return is_null($this->resourceIdentifier);
     }
 }

--- a/src/JsonApi/Request/Request.php
+++ b/src/JsonApi/Request/Request.php
@@ -538,11 +538,18 @@ class Request implements RequestInterface
     {
         $data = $this->getResource();
 
-        if (isset($data["relationships"][$relationship]["data"]) === false) {
-            return null;
+        //The relationship has to exist in the request and have a data attribute to be valid
+        if (isset($data["relationships"][$relationship]) &&
+            array_key_exists("data", $data["relationships"][$relationship])
+        ) {
+            //If the data is null, this request is to clear the relationship, we return an empty relationship
+            if (is_null($data["relationships"][$relationship]["data"])) {
+                return new ToOneRelationship();
+            }
+            //If the data is set and is not null, we create the relationship with a resourceidentifier from the request
+            return new ToOneRelationship(ResourceIdentifier::fromArray($data["relationships"][$relationship]["data"]));
         }
-
-        return new ToOneRelationship(ResourceIdentifier::fromArray($data["relationships"][$relationship]["data"]));
+        return null;
     }
 
     /**


### PR DESCRIPTION
If you sent a request, trying to clear a relationship (remove the relationship) by sending `"relationshipname" : { "data": null}"` yin ignored this, behaving exactly like it did when the relationship was completely omitted.
The hydrator for the relationship was not called and calls to `$jsonApi->getRequest()->getResourceToOneRelationship('relationshipname')` behaved just as if no relationship was sent.
This patch intends to change that by handling the null-case and creating empty ToOneRelationships where appropriate.

A request for clarification of this behavior has been made to the folks over at jsonapi, here: https://github.com/json-api/json-api/issues/1070
