### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0 - unreleased
+## 0.11.0 - unreleased
 
 ADDED:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.11.0 - unreleased
+## 1.0.0 - unreleased
 
 ADDED:
 
@@ -11,6 +11,7 @@ CHANGED:
 - Slightly optimized request body serialization
 - Renamed `Request::getResourceToOneRelationship()` to `Request::getToOneRelationship()`
 - Renamed `Request::getResourceToManyRelationship()` to `Request::getToManyRelationship()`
+- Changed the signature of the `Request` contructor from `Request::__construct(ServerRequestInterface $request)` to `public function __construct(ServerRequestInterface $request, ExceptionFactoryInterface $exceptionFactory)`
 
 REMOVED:
 


### PR DESCRIPTION
I tried to use the latest commit on master as a dependency in a project as i needed currently un-released changes. I ran into some changes that broke the application. 

The first one was documented here, the renaming of `getResourceToOneRelationship` and `getResourceToManyRelationship`.

The second one was not, the change of the constructor signature of the Request class.

The change can be found here: `https://github.com/woohoolabs/yin/commit/78c316db9d39cdb0bf9a4333c58339fb8e51dea6#diff-8b9b082f8f14fc68d1683252b988283eR59

I added it to the changelog and changed the version to 1.0.0. I know 1.0 feels like a very significant release but if this project follows semver (the readme states it and I think it would be great if it did), this version should really be a major version bump. :)

Following semver would make it easier to set proper version constraints in your composer file and avoid updating to breaking changes.

Bumping to 1.0.0 is also a great reason to celebrate with an extra beer this weekend. :) 

![https://media.giphy.com/media/ixCowc31ZeKuIHuhFe/giphy.gif](https://media.giphy.com/media/ixCowc31ZeKuIHuhFe/giphy.gif)

What is your opinion on all this?
