### PR TITLE
Fix typos and clarify language

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
     * [Loading relationship data efficiently](#loading-relationship-data-efficiently)
     * [Injecting metadata into documents](#injecting-metadata-into-documents)
     * [Content negotiation](#content-negotiation)
-    * [Request/response validation](#request-response-validation)
+    * [Request/response validation](#requestresponse-validation)
     * [Middleware](#middleware)
 * [Examples](#examples)
     * [Fetching a single resource](#fetching-a-single-resource)
@@ -48,7 +48,7 @@
 
 [JSON:API](http://jsonapi.org) specification
 [reached 1.0 on 29th May 2015](http://www.programmableweb.com/news/new-json-api-specification-aims-to-speed-api-development/2015/06/10)
-and we also believe it is a big day for RESTful API-s as this specification can help you to make APIs more robust and future-proof. Woohoo Labs. Yin (named after Yin-Yang) was born to bring efficiency and elegance for your JSON:API servers.
+and we also believe it is a big day for RESTful APIs as this specification can help you make APIs more robust and future-proof. Woohoo Labs. Yin (named after Yin-Yang) was born to bring efficiency and elegance for your JSON:API servers.
 
 #### Features
 
@@ -66,27 +66,26 @@ and we also believe it is a big day for RESTful API-s as this specification can 
 
 Woohoo Labs. Yin is a framework-agnostic library which supports the vast majority of the JSON:API specification: it provides various
 capabilities from content negotiation, through error handling to pagination, fetching, creation, updating and
-deletion of resources. Although Yin consists of many loosely coupled packages and classes which can also be used
-separately, the framework is the most powerful when it is used in its entirety.
+deletion of resources. Although Yin consists of many loosely coupled packages and classes which can be used
+separately, the framework is most powerful when used in its entirety.
 
 ##### Efficiency
 
-We designed Yin to be as efficient as possible. That's why attributes and relationships are transformed only and if
-only they are requested. This feature is extremely advantageous when there are a lot of resources to transform or a
+We designed Yin to be as efficient as possible. That's why attributes and relationships are transformed if and only if they are requested. This feature is extremely advantageous when there are numerous resources to transform or a
 rarely required transformation is very expensive. Furthermore, as transformers are stateless, the overhead of having a
 separate model object for each resource is avoided. Additionally, due to statelessness, the overall library works really
 well with dependency injection.
 
 ##### Supplementary middleware
 
-[There are some additional middleware](https://github.com/woohoolabs/yin-middleware) for Woohoo Labs. Yin you might
+[There is some additional middleware](https://github.com/woohoolabs/yin-middleware) for Woohoo Labs. Yin you might
 find useful: they can facilitate various tasks like error handling (via transformation of exceptions into JSON:API
 error messages), dispatching JSON:API-aware controllers or debugging (via syntax checking and validation of requests
 and responses).
 
 ## Install
 
-You need [Composer](https://getcomposer.org) to install this library. As Yin requires a PSR-7 implementation (a package which provides the `http-message-implementation` virtual package), you must install one first. You may use Zend Diactoros or your preferred library:
+You need [Composer](https://getcomposer.org) to install this library. You must install a PSR-7 implementation first(a package which provides the `http-message-implementation` virtual package), as Yin requires one. You may use Zend Diactoros or your preferred library:
 
 ```bash
 $ composer require zendframework/zend-diactoros
@@ -98,8 +97,8 @@ Now, you can run the command below and you will get the latest version of Yin:
 $ composer require woohoolabs/yin
 ```
 
-If you want to take advantage from request/response validation then you have to ask for the following
-dependencies too:
+If you want to take advantage of request/response validation then you also have to ask for the following
+dependencies:
 
 ```bash
 $ composer require justinrainbow/json-schema:^2.0.0
@@ -117,12 +116,12 @@ Furthermore, a `JsonApi` class will be responsible for the instrumentation, whil
 
 #### Documents
 
-The following sections will guide you through how to create documents for successful responses and
-how to create or build error documents.
+The following sections will guide you through creating documents for successful responses and
+creating or building error documents.
 
 ##### Documents for successful responses
 
-For successful requests, you have to return information about one or more resources. Woohoo Labs. Yin provides
+For successful requests, you must return information about one or more resources. Woohoo Labs. Yin provides
 multiple abstract classes that help you to create your own documents for the different use cases:
 
 - `AbstractSuccessfulDocument`: A generic base document for successful responses
@@ -131,8 +130,8 @@ multiple abstract classes that help you to create your own documents for the dif
 - `AbstractCollectionDocument`: A base class for documents about a collection of top-level resources
 
 The difference between the `AbstractSimpleResourceDocument` and the `AbstractSingleResourceDocument` classes is that
-the first one doesn't need a [resource transformer](#resource-transformers) so it is preferable to use for really simple
-domain objects (like messages) while the latter works better for more complex domain objects (like users or addresses).
+the first one doesn't need a [resource transformer](#resource-transformers). For this reason, it is preferable to use the former for really simple
+domain objects (like messages), while the latter works better for more complex domain objects (like users or addresses).
 
 As the `AbstractSuccessfulDocument` is only useful for special use-cases (e.g. when a document can contain resources
 of multiple types), we will not cover it here.
@@ -195,7 +194,7 @@ public function getMeta()
 }
 ```
 
-Documents can also have a meta section which can contain any non-standard information. The example above adds a
+Documents may also have a meta section which can contain any non-standard information. The example above adds a
 [profile](http://jsonapi.org/extensions/#profiles) and some information about pagination to the document.
 
 Note that the `domainObject` property is a variable of any type (in this case it is a hypothetical collection),
@@ -275,14 +274,14 @@ Documents for successful responses can contain one or more top-level resources, 
 resource identifier objects as relationships. That's why resource transformers are responsible for converting a
 domain object into a JSON:API resource or resource identifier.
 
-Although you are encouraged to create one transformer for each resource type, there is possibility to define
-"composite" resource transformers too following the Composite design pattern if you need more sophistication.
+Although you are encouraged to create one transformer for each resource type, it is also possible to define
+"composite" resource transformers by following the Composite design pattern if you need more sophistication.
 
-Resource transformers must implement the `ResourceTransformerInterface`, but to facilitate this job, you can extend
-the `AbstractResourceTransformer` class too.
+Resource transformers must implement the `ResourceTransformerInterface`, but to facilitate this job, you can also extend
+the `AbstractResourceTransformer` class.
 
 Children of the `AbstractResourceTransformer` class need several abstract methods to be implemented, most of which
-are the same as it was seen at the documents. The following example illustrates a resource transformer dealing with
+are the same as seen in the documents. The following example illustrates a resource transformer dealing with
 a book domain object and its "authors" and "publisher" relationships.
 
 ```php
@@ -449,7 +448,7 @@ the "included" and the "relationship" sections in the responses.
 #### Hydrators
 
 Hydrators allow us to initialize the properties of a domain object as required by the current HTTP request. This means
-when a client wants to create or update a resource, hydrators can help to instantiate a domain object which can then be
+when a client wants to create or update a resource, hydrators can help instantiate a domain object, which can then be
 validated, saved etc.
 
 There are three abstract hydrator classes in Woohoo Labs. Yin:
@@ -459,7 +458,7 @@ There are three abstract hydrator classes in Woohoo Labs. Yin:
 - `AbstractHydrator`: It can be used for both type of requests
 
 For the sake of brevity, we only introduce the usage of the latter class as it is simply the union of the
-`AbstractCreateHydrator` and `AbstractUpdateHydrator`. Let's see how an example hydrator looks like:
+`AbstractCreateHydrator` and `AbstractUpdateHydrator`. Let's look at an example hydrator:
 
 ```php
 class BookHydator extends AbstractHydrator
@@ -651,7 +650,7 @@ Array
 Woohoo Labs. Yin was designed to make error handling as easy and customizable as possible. That's why
 all the default exceptions extend the `JsonApiException` class and contain
 an [error document](#documents-for-error-responses) with the appropriate error object(s). That said, if you
-only want to respond with an error document in case of an exception, you only need to do this:
+only want to respond with an error document in case of an exception, you need only do this:
 
 ```php
 try {
@@ -686,8 +685,8 @@ This section guides you through the advanced features of Yin.
 
 #### Loading relationship data efficiently
 
-Sometimes it can be beneficent or necessary to fine-tune the returned relationships' data. A possible scenario might be
-when you have a "to-many" relationship with lots of items. In this case you might only want to return a data key of a
+Sometimes it can be beneficial or necessary to fine-tune the data of the returned relationship. A possible scenario might be
+when you have a "to-many" relationship with multiple items. In this case you might only want to return a data key of a
 relationship when the relationship itself is included in the response. This optimization can save you bandwidth by
 omitting resource linkage.
 
@@ -709,7 +708,7 @@ public function getRelationships($user)
 }
 ```
 
-With the usage of the `omitWhenNotIncluded()` method, the relationship data will be omitted when the relationship is not
+With usage of the `omitWhenNotIncluded()` method, the relationship data will be omitted when the relationship is not
 included. But sometimes this optimization is not enough on its own: even though we can save bandwidth with the prior
 technique, the relationship still has to be loaded from the data source (probably from a database), because we pass it
 to the relationship object with the `setData()` method.
@@ -738,12 +737,12 @@ public function getRelationships($user)
 }
 ```
 
-This way, the contacts of a user will only be loaded when the given relationship's `data` key is present in the response
+This way, the contacts of a user will only be loaded when the given relationship's `data` key is present in the response,
 allowing your API to be as effective as possible.
 
 #### Injecting metadata into documents
 
-Metadata can be injected into documents on-the-fly. This might can handy if you want to customize/decorate your
+Metadata can be injected into documents on-the-fly. This can be handy if you want to customize/decorate your
 responses (e.g.: providing a cache ID to the returned document).
 
 The easiest way to check this functionality is to have a look at the [first examples](#fetching-a-single-resource),
@@ -775,11 +774,10 @@ a request validator to see it in action:
 $requestValidator = new RequestValidator(new DefaultExceptionFactory(), $includeOriginalMessageInResponse);
 ```
 
-Providing an [Exception Factory](#exceptions) is necessary to be able to customize the exceptions which are possibly
-thrown. On the other hand, the `$includeOriginalMessageInResponse` argument can be useful in a development environment
+To customize the exceptions which can be thrown, it is necessary to provide an [Exception Factory](#exceptions). On the other hand, the `$includeOriginalMessageInResponse` argument can be useful in a development environment
 when you also want to return the original message in the error response which may be triggered by the exception.
 
-In order to validate if the current request's `Accept` and `Content-Type` headers conform to the JSON:API specification,
+In order to check if the current request's `Accept` and `Content-Type` headers conform to the JSON:API specification,
 use this method:
 
 ```php
@@ -1021,7 +1019,7 @@ public function updateBookRelationship(JsonApi $jsonApi)
 ```
 
 #### How to try it out
-If you want to get to know more how Yin works, have a look at the
+If you want to know more about how Yin works, have a look at the
 [examples](https://github.com/woohoolabs/yin/tree/master/examples): set up a web server, run `composer install` in
 Yin's root directory and visit the URL-s listed below. You can restrict the retrieved fields and relationships with
 the `fields` and `include` parameters as specified by JSON:API.


### PR DESCRIPTION
Fixed broken "Request/response" link and typos, clarified language and syntax.
