### PR TITLE
Testing MessageValidator::lintMessage method

### DIFF
--- a/src/JsonApi/Negotiation/MessageValidator.php
+++ b/src/JsonApi/Negotiation/MessageValidator.php
@@ -35,10 +35,10 @@ abstract class MessageValidator
      * @param string $message
      * @return string
      */
-    public function lintMessage($message)
+    protected function lintMessage($message)
     {
         if (empty($message) === true) {
-            return null;
+            return "";
         }
 
         try {

--- a/src/JsonApi/Request/Request.php
+++ b/src/JsonApi/Request/Request.php
@@ -105,7 +105,7 @@ class Request implements RequestInterface
     protected function isValidMediaTypeHeader($headerName)
     {
         $header = $this->getHeaderLine($headerName);
-        return (strpos($header, "application/vnd.api+json") === false || $header === "application/vnd.api+json");
+        return strpos($header, "application/vnd.api+json") !== false;
     }
 
     protected function setIncludedFields()

--- a/tests/JsonApi/Negotiation/RequestValidatorTest.php
+++ b/tests/JsonApi/Negotiation/RequestValidatorTest.php
@@ -1,0 +1,124 @@
+<?php
+namespace WoohooLabs\Yin\JsonApi\Negotiation;
+
+use PHPUnit_Framework_TestCase;
+use WoohooLabs\Yin\JsonApi\Request\Request;
+use WoohooLabs\Yin\JsonApi\Exception\DefaultExceptionFactory;
+
+class RequestValidatorTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test valid request without Request validation Exceptions
+     * @test
+     */
+    public function negotiateValidRequest()
+    {
+        $server = $this->getMockForAbstractClass('\Psr\Http\Message\ServerRequestInterface');
+        $exceptionFactory = $this->getMockForAbstractClass('\WoohooLabs\Yin\JsonApi\Exception\ExceptionFactoryInterface');
+
+        $request = $this->createRequestMock($server, $exceptionFactory);
+
+        $request->expects($this->once())
+            ->method('validateContentTypeHeader')
+            ->will($this->returnValue(true));
+        ;
+
+        $request->expects($this->once())
+            ->method('validateAcceptHeader')
+            ->will($this->returnValue(true));
+        ;
+
+        $validator = $this->createRequestValidator($server);
+
+        $validator->negotiate($request);
+    }
+
+
+    /**
+     * @test
+     * @dataProvider getInvalidContentTypes
+     * @expectedException \WoohooLabs\Yin\JsonApi\Exception\MediaTypeUnsupported
+     */
+    public function negotiateTrowMediaTypeUnsupported($contentType)
+    {
+        // Content type is invalid Accept is valid
+        $server = $this->createServerRequest($contentType, 'application/vnd.api+json');
+
+        $request = $this->createRequest($server, $contentType);
+        $validator = $this->createRequestValidator($server);
+
+        $validator->negotiate($request);
+    }
+
+    /**
+     * @test
+     * @dataProvider getInvalidContentTypes
+     * @expectedException \WoohooLabs\Yin\JsonApi\Exception\MediaTypeUnacceptable
+     */
+    public function negotiateThrowTypeUnacceptable($accept)
+    {
+        // Content Type is valid, Accept is invalid
+        $server = $this->createServerRequest('application/vnd.api+json', $accept);
+
+        $request = $this->createRequest($server, 'application/vnd.api+json');
+        $validator = $this->createRequestValidator($server);
+
+        $validator->negotiate($request);
+    }
+
+    public function createServerRequest($contentType, $accept = '')
+    {
+        $server = $this->getMockForAbstractClass('\Psr\Http\Message\ServerRequestInterface');
+
+        $map = array(
+            array('Content-Type', $contentType),
+            array('Accept', $accept)
+        );
+        $server->expects($this->any())
+            ->method('getHeaderLine')
+            ->will($this->returnValueMap($map));
+
+
+        return $server;
+    }
+
+
+    public function createRequest($server, $contentType)
+    {
+        $exceptionInterface = new DefaultExceptionFactory($server);
+
+        $request = new Request($server, $exceptionInterface);
+
+        return $request;
+    }
+
+    protected function createRequestMock($server, $exceptionFactory)
+    {
+        return $this->getMockForAbstractClass('\WoohooLabs\Yin\JsonApi\Request\RequestInterface', [$server, $exceptionFactory]);
+    }
+
+
+    private function createRequestValidator($server, $includeOriginalMessageResponse = true)
+    {
+        $exceptionInterface = new DefaultExceptionFactory($server);
+        return new RequestValidator($exceptionInterface, $includeOriginalMessageResponse);
+    }
+
+    public function getInvalidContentTypes()
+    {
+        return [
+          ['application/zip'],
+          ['application/octet-stream'],
+          ['application/ms-word'],
+          ['application/json'],
+          ['application/x-javascript'],
+        ];
+    }
+
+    public function getValidContentTypes()
+    {
+        return [
+            ['application/vnd.api+json']
+        ];
+    }
+}


### PR DESCRIPTION
Improving test coverage #39 

I tested the method `MessageValidator::lintMessage`, and this PR is not ready for the test since test is not green.

I will explain why. I tested only this method, isolated, that is why I only test his responses.

If the message is valid `lintMessage` will return an empty string, if it is not valid it will return `string` error message.  NOTE: It will not throw an Exception, which can be expected IMHO. This is why `MessageValidator::lintMessage` can't catch the `\Seld\JsonLint\ParsingException` and this method always return an empty string, even for not valid messages.

Method `lint` in `\Seld\JsonLint\JsonParser` class will return `null` if message is valid, and if message is not valid it will `return` Exception object.

We can talk about the design of this classes if you want, or we can just discuss expectation in test method `invalidJsonMessage`. I expect to get the error message if the message is not valid. If would be better to throw the exception instead of returning error string IMHO.

What are next steps about this issue?
