### PR TITLE
RequestValidator covered with integration tests …

### DIFF
--- a/src/JsonApi/Negotiation/RequestValidator.php
+++ b/src/JsonApi/Negotiation/RequestValidator.php
@@ -59,7 +59,7 @@ class RequestValidator extends MessageValidator
         $errorMessage = $this->lintMessage($request->getBody());
 
         if (empty($errorMessage) === false) {
-            $this->exceptionFactory->createRequestBodyInvalidJsonException(
+            throw $this->exceptionFactory->createRequestBodyInvalidJsonException(
                 $request,
                 $errorMessage,
                 $this->includeOriginalMessage

--- a/tests/JsonApi/Negotiation/RequestValidatorTest.php
+++ b/tests/JsonApi/Negotiation/RequestValidatorTest.php
@@ -2,11 +2,11 @@
 namespace WoohooLabs\Yin\JsonApi\Negotiation;
 
 use PHPUnit\Framework\TestCase;
+use WoohooLabs\Yin\JsonApi\Request\Request;
 use Psr\Http\Message\ServerRequestInterface;
+use WoohooLabs\Yin\JsonApi\Request\RequestInterface;
 use WoohooLabs\Yin\JsonApi\Exception\DefaultExceptionFactory;
 use WoohooLabs\Yin\JsonApi\Exception\ExceptionFactoryInterface;
-use WoohooLabs\Yin\JsonApi\Request\Request;
-use WoohooLabs\Yin\JsonApi\Request\RequestInterface;
 
 class RequestValidatorTest extends TestCase
 {
@@ -68,6 +68,100 @@ class RequestValidatorTest extends TestCase
         $validator->negotiate($request);
     }
 
+    /**
+     * @test
+     */
+    public function validQueryParams()
+    {
+        $server = $this->createServerRequest("application/vnd.api+json");
+        $server->expects($this->once())
+            ->method("getQueryParams")
+            ->will($this->returnValue([
+                    "fields" => ["foo" => "bar"],
+                    "include" => "baz",
+                    "sort" => "asc",
+                    "page" => "1",
+                    "filter" => "search"
+                ]
+            ));
+
+        $request = $this->createRequest($server, "application/vnd.api+json");
+        $validator = $this->createRequestValidator($server);
+
+        $response = $validator->validateQueryParams($request);
+
+        $this->assertNull($response);
+    }
+
+    /**
+     * @test
+     * @expectedException \WoohooLabs\Yin\JsonApi\Exception\QueryParamUnrecognized
+     * @expectedExceptionMessage Query parameter 'foo' can't be recognized!
+     */
+    public function invalidQueryParamsThrowException()
+    {
+        $server = $this->createServerRequest("application/vnd.api+json");
+        $server->expects($this->once())
+            ->method("getQueryParams")
+            ->will($this->returnValue(["foo" => "bar"]));
+
+        $request = $this->createRequest($server, "application/vnd.api+json");
+        $validator = $this->createRequestValidator($server);
+
+        $response = $validator->validateQueryParams($request);
+
+        $this->assertNull($response);
+    }
+
+    /**
+     * @test
+     * @dataProvider getEmptyMessages
+     */
+    public function lintOnEmptyMessageReturnNull($message)
+    {
+        $server = $this->createServerRequest("application/vnd.api+json");
+        $this->setFakeBody($server, $message);
+        $request = $this->createRequest($server, "application/vnd.api+json");
+        $validator = $this->createRequestValidator($server);
+
+        $response = $validator->lintBody($request);
+
+        $this->assertNull($response);
+    }
+
+    /**
+     * @test
+     * @dataProvider getValidJsonMessages
+     */
+    public function lintOnValidMessageReturnNull($message)
+    {
+        $server = $this->createServerRequest("application/vnd.api+json");
+        $this->setFakeBody($server, $message);
+        $request = $this->createRequest($server, "application/vnd.api+json");
+        $validator = $this->createRequestValidator($server);
+
+        $response = $validator->lintBody($request);
+
+        $this->assertNull($response);
+    }
+
+    /**
+     * @test
+     * @dataProvider getInvalidJsonMessages
+     * @expectedException \WoohooLabs\Yin\JsonApi\Exception\RequestBodyInvalidJson
+     */
+    public function lintOnInvalidMessageThrowException($message)
+    {
+        $server = $this->createServerRequest("application/vnd.api+json");
+        $this->setFakeBody($server, $message);
+        $request = $this->createRequest($server, "application/vnd.api+json");
+        $validator = $this->createRequestValidator($server);
+
+        $response = $validator->lintBody($request);
+
+        $this->assertNull($response);
+    }
+
     public function createServerRequest($contentType, $accept = "")
     {
         $server = $this->getMockForAbstractClass(ServerRequestInterface::class);
@@ -94,6 +188,13 @@ class RequestValidatorTest extends TestCase
         return $request;
     }
 
+    protected function setFakeBody($server, $body)
+    {
+        $server->expects($this->once())
+            ->method("getBody")
+            ->will($this->returnValue($body));
+    }
+
     protected function createRequestMock($server, $exceptionFactory)
     {
         return $this->getMockForAbstractClass(RequestInterface::class, [$server, $exceptionFactory]);
@@ -108,8 +209,8 @@ class RequestValidatorTest extends TestCase
     public function getInvalidContentTypes()
     {
         return [
-          ["application/vnd.api+json; charset=utf-8"],
-          ['application/vnd.api+json; ext="ext1,ext2"'],
+            ["application/vnd.api+json; charset=utf-8"],
+            ['application/vnd.api+json; ext="ext1,ext2"'],
         ];
     }
 
@@ -118,6 +219,31 @@ class RequestValidatorTest extends TestCase
         return [
             ["application/vnd.api+json"],
             ["text/html; charset=utf-8"],
+        ];
+    }
+
+    public function getEmptyMessages()
+    {
+        return [[''], [null], [0]];
+    }
+
+    public function getValidJsonMessages()
+    {
+        return [
+            ['{}'],
+            ['{"employees":[
+                {"firstName":"John", "lastName":"Doe"},
+                {"firstName":"Anna", "lastName":"Smith"},
+                {"firstName":"Peter", "lastName":"Jones"}
+            ]}'],
+        ];
+    }
+
+    public function getInvalidJsonMessages()
+    {
+        return [
+            ['abc'],
+            ["\xEF\xBB\xBF"],
         ];
     }
 }


### PR DESCRIPTION
Added integration tests for `validateQueryParams` and `lintBody` for `RequestValidator` class.

Method lintBody wasn't throwing and Exception because `throw` was missing. That is fixed.

Addition to issue #39 
