### PR TITLE
PageBasedPaginationLinkProviderTrait: Fix getPrevLink, getNextLink and getLastPage

### DIFF
--- a/src/JsonApi/Schema/Pagination/PageBasedPaginationLinkProviderTrait.php
+++ b/src/JsonApi/Schema/Pagination/PageBasedPaginationLinkProviderTrait.php
@@ -53,7 +53,7 @@ trait PageBasedPaginationLinkProviderTrait
             return null;
         }
 
-        $page = floor(($this->getTotalItems() - 1) / $this->getSize()) + 1;
+        $page = $this->getLastPage();
         return $this->createPaginatedLink($url, $page, $this->getSize());
     }
 
@@ -63,7 +63,7 @@ trait PageBasedPaginationLinkProviderTrait
      */
     public function getPrevLink($url)
     {
-        if ($this->getPage() <= 1 || $this->getSize() <= 0 || $this->getPage() >= $this->getLastPage()) {
+        if ($this->getPage() <= 1 || $this->getSize() <= 0) {
             return null;
         }
 
@@ -76,7 +76,7 @@ trait PageBasedPaginationLinkProviderTrait
      */
     public function getNextLink($url)
     {
-        if ($this->getPage() <= 0 || $this->getSize() <= 0 || $this->getPage() + 1 >= $this->getLastPage()) {
+        if ($this->getPage() <= 0 || $this->getSize() <= 0 || $this->getPage() >= $this->getLastPage()) {
             return null;
         }
 
@@ -119,6 +119,6 @@ trait PageBasedPaginationLinkProviderTrait
      */
     protected function getLastPage()
     {
-        return floor($this->getTotalItems() / $this->getSize()) + 1;
+        return ceil($this->getTotalItems() / $this->getSize());
     }
 }

--- a/tests/JsonApi/Schema/Pagination/PageBasedPaginationProviderTraitTest.php
+++ b/tests/JsonApi/Schema/Pagination/PageBasedPaginationProviderTraitTest.php
@@ -247,6 +247,20 @@ class PageBasedPaginationProviderTraitTest extends TestCase
     /**
      * @test
      */
+    public function getPrevLinkWhenPageIsLast()
+    {
+        $url = "http://example.com/api/users";
+        $totalItems = 50;
+        $page = 5;
+        $size = 10;
+
+        $provider = $this->createProvider($totalItems, $page, $size);
+        $this->assertEquals("$url?page[number]=4&page[size]=$size", $provider->getPrevLink($url)->getHref());
+    }
+
+    /**
+     * @test
+     */
     public function getPrevLink()
     {
         $url = "http://example.com/api/users";
@@ -270,6 +284,20 @@ class PageBasedPaginationProviderTraitTest extends TestCase
 
         $provider = $this->createProvider($totalItems, $page, $size);
         $this->assertNull($provider->getNextLink($url));
+    }
+
+    /**
+     * @test
+     */
+    public function getNextLinkWhenPageIsBeforeLast()
+    {
+        $url = "http://example.com/api/users";
+        $totalItems = 50;
+        $page = 4;
+        $size = 10;
+
+        $provider = $this->createProvider($totalItems, $page, $size);
+        $this->assertEquals("$url?page[number]=5&page[size]=$size", $provider->getNextLink($url)->getHref());
     }
 
     /**


### PR DESCRIPTION
Hi,

This PR fixes #48. I added two additional tests about it.
When I fixed the issues in #48 and ran the tests, getNextLinkWhenPageIsLast failed, so I have found another issue in getLastPage and fixed it, making it simpler to read.

Please let me know if you approve the changes and if I need to do something else.
