### PR TITLE
Decouple AbstractSuccessfulDocument from Serializer and Response

### DIFF
--- a/src/JsonApi/Document/AbstractSuccessfulDocument.php
+++ b/src/JsonApi/Document/AbstractSuccessfulDocument.php
@@ -1,10 +1,8 @@
 <?php
 namespace WoohooLabs\Yin\JsonApi\Document;
 
-use Psr\Http\Message\ResponseInterface;
-use WoohooLabs\Yin\JsonApi\Exception\ExceptionFactoryInterface;
 use WoohooLabs\Yin\JsonApi\Request\RequestInterface;
-use WoohooLabs\Yin\JsonApi\Serializer\SerializerInterface;
+use WoohooLabs\Yin\JsonApi\Exception\ExceptionFactoryInterface;
 use WoohooLabs\Yin\JsonApi\Transformer\Transformation;
 
 abstract class AbstractSuccessfulDocument extends AbstractDocument
@@ -27,8 +25,6 @@ abstract class AbstractSuccessfulDocument extends AbstractDocument
     abstract protected function fillData(Transformation $transformation);
 
     /**
-     * Returns a response content whose primary data is a relationship object with $relationshipName name. You can also
-     * pass additional meta information for the document in the $additionalMeta argument.
      *
      * @param string $relationshipName
      * @param \WoohooLabs\Yin\JsonApi\Transformer\Transformation $transformation
@@ -42,94 +38,66 @@ abstract class AbstractSuccessfulDocument extends AbstractDocument
     );
 
     /**
-     * Returns a response with a status code of $responseCode, containing all the provided members of the document,
-     * assembled based on the $domainObject. You can also pass additional meta information for the document in the
-     * $additionalMeta argument.
+     *
+     * Transform a $domainObject resource in a jsonapi format
      *
      * @param \WoohooLabs\Yin\JsonApi\Request\RequestInterface $request
-     * @param \Psr\Http\Message\ResponseInterface $response
      * @param \WoohooLabs\Yin\JsonApi\Exception\ExceptionFactoryInterface $exceptionFactory
-     * @param SerializerInterface $serializer
      * @param mixed $domainObject
-     * @param int $responseCode
      * @param array $additionalMeta
-     * @return \Psr\Http\Message\ResponseInterface
+     * @return array
      */
-    public function getResponse(
+    public function getContent(
         RequestInterface $request,
-        ResponseInterface $response,
         ExceptionFactoryInterface $exceptionFactory,
-        SerializerInterface $serializer,
         $domainObject,
-        $responseCode,
         array $additionalMeta = []
     ) {
         $transformation = new Transformation($request, $this->createData(), $exceptionFactory, "");
 
         $this->initializeDocument($domainObject);
-        $content = $this->transformContent($transformation, $additionalMeta);
 
-        return $serializer->serialize($response, $responseCode, $content);
+        return $this->transformContent($transformation, $additionalMeta);
     }
 
     /**
-     * Returns a response with a status code of $responseCode, only containing meta information (without the "data" and
-     * the "included" members) about the document, assembled based on the $domainObject. You can also pass additional
-     * meta information to the document in the $additionalMeta argument.
      *
      * @param \WoohooLabs\Yin\JsonApi\Request\RequestInterface $request
-     * @param \Psr\Http\Message\ResponseInterface $response
      * @param \WoohooLabs\Yin\JsonApi\Exception\ExceptionFactoryInterface $exceptionFactory
-     * @param SerializerInterface $serializer
      * @param mixed $domainObject
-     * @param int $responseCode
      * @param array $additionalMeta
-     * @return \Psr\Http\Message\ResponseInterface
+     * @return array
      */
-    public function getMetaResponse(
+    public function getMetaContent(
         RequestInterface $request,
-        ResponseInterface $response,
         ExceptionFactoryInterface $exceptionFactory,
-        SerializerInterface $serializer,
         $domainObject,
-        $responseCode,
         array $additionalMeta = []
     ) {
         $this->initializeDocument($domainObject);
-        $content = $this->transformBaseContent($additionalMeta);
 
-        return $serializer->serialize($response, $responseCode, $content);
+        return $this->transformBaseContent($additionalMeta);
     }
 
     /**
-     * Returns a response with a status code of $responseCode, containing the $relationshipName relationship object as
-     * the primary data, assembled based on the $domainObject. You can also pass additional meta information to the
-     * document in the $additionalMeta argument.
      *
      * @param string $relationshipName
      * @param \WoohooLabs\Yin\JsonApi\Request\RequestInterface $request
-     * @param \Psr\Http\Message\ResponseInterface $response
      * @param \WoohooLabs\Yin\JsonApi\Exception\ExceptionFactoryInterface $exceptionFactory
      * @param mixed $domainObject
-     * @param int $responseCode
      * @param array $additionalMeta
-     * @return \Psr\Http\Message\ResponseInterface
+     * @return array
      */
-    public function getRelationshipResponse(
+    public function getRelationship(
         $relationshipName,
         RequestInterface $request,
-        ResponseInterface $response,
         ExceptionFactoryInterface $exceptionFactory,
-        SerializerInterface $serializer,
         $domainObject,
-        $responseCode,
         array $additionalMeta = []
     ) {
         $transformation = new Transformation($request, $this->createData(), $exceptionFactory, "");
         $this->initializeDocument($domainObject);
-        $content = $this->transformRelationshipContent($relationshipName, $transformation, $additionalMeta);
-
-        return $serializer->serialize($response, $responseCode, $content);
+        return $this->transformRelationshipContent($relationshipName, $transformation, $additionalMeta);
     }
 
     /**
@@ -172,13 +140,13 @@ abstract class AbstractSuccessfulDocument extends AbstractDocument
         Transformation $transformation,
         array $additionalMeta = []
     ) {
-        $response = $this->getRelationshipContent($relationshipName, $transformation, $additionalMeta);
+        $content = $this->getRelationshipContent($relationshipName, $transformation, $additionalMeta);
 
         // Included
         if ($transformation->data->hasIncludedResources()) {
-            $response["included"] = $transformation->data->transformIncludedResources();
+            $content["included"] = $transformation->data->transformIncludedResources();
         }
 
-        return $response;
+        return $content;
     }
 }

--- a/src/JsonApi/Response/AbstractResponder.php
+++ b/src/JsonApi/Response/AbstractResponder.php
@@ -55,14 +55,17 @@ abstract class AbstractResponder
         $statusCode,
         array $additionalMeta = []
     ) {
-        return $document->getResponse(
+        $content = $document->getContent(
             $this->request,
-            $this->response,
             $this->exceptionFactory,
-            $this->serializer,
             $domainObject,
-            $statusCode,
             $additionalMeta
+        );
+
+        return $this->serializer->serialize(
+            $this->response,
+            $statusCode,
+            $content
         );
     }
 
@@ -79,14 +82,17 @@ abstract class AbstractResponder
         $statusCode,
         array $additionalMeta = []
     ) {
-        return $document->getMetaResponse(
+        $content = $document->getMetaContent(
             $this->request,
-            $this->response,
             $this->exceptionFactory,
-            $this->serializer,
             $domainObject,
-            $statusCode,
             $additionalMeta
+        );
+
+        return $this->serializer->serialize(
+            $this->response,
+            $statusCode,
+            $content
         );
     }
 
@@ -105,15 +111,18 @@ abstract class AbstractResponder
         $statusCode,
         array $additionalMeta = []
     ) {
-        return $document->getRelationshipResponse(
+        $content = $document->getRelationship(
             $relationshipName,
             $this->request,
-            $this->response,
             $this->exceptionFactory,
-            $this->serializer,
             $domainObject,
-            $statusCode,
             $additionalMeta
+        );
+
+        return $this->serializer->serialize(
+            $this->response,
+            $statusCode,
+            $content
         );
     }
 
@@ -132,15 +141,18 @@ abstract class AbstractResponder
         $statusCode,
         array $additionalMeta = []
     ) {
-        return $document->getRelationshipResponse(
+        $content = $document->getRelationship(
             $relationshipName,
             $this->request,
-            $this->response,
             $this->exceptionFactory,
-            $this->serializer,
             $domainObject,
-            $statusCode,
             $additionalMeta
+        );
+
+        return $this->serializer->serialize(
+            $this->response,
+            $statusCode,
+            $content
         );
     }
 

--- a/tests/JsonApi/Document/AbstractSuccessfulDocumentTest.php
+++ b/tests/JsonApi/Document/AbstractSuccessfulDocumentTest.php
@@ -20,132 +20,121 @@ class AbstractSuccessfulDocumentTest extends TestCase
     /**
      * @test
      */
-    public function getResponse()
+    public function getContent()
     {
         $request = new Request(new ServerRequest(), new DefaultExceptionFactory());
-        $responseCode = 200;
+
         $version = "1.0";
 
         $document = $this->createDocument(new JsonApi($version));
-        $response = $document->getMetaResponse(
+        $content = $document->getMetaContent(
             $request,
-            new Response(),
             new DefaultExceptionFactory(),
-            new DefaultSerializer(),
-            [],
-            $responseCode
+            []
         );
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals(["application/vnd.api+json"], $response->getHeader("Content-Type"));
-        $this->assertEquals("1.0", $this->getContentFromResponse("jsonapi", $response)["version"]);
+
+        $this->assertArrayHasKey('jsonapi', $content);
+        $this->assertArrayHasKey('version', $content['jsonapi']);
+        $this->assertEquals('1.0', $content['jsonapi']['version']);
     }
 
     /**
      * @test
      */
-    public function getEmptyMetaResponse()
+    public function getEmptyMetaContent()
     {
         $request = new Request(new ServerRequest(), new DefaultExceptionFactory());
         $meta = [];
-        $responseCode = 200;
 
         $document = $this->createDocument(null, $meta);
-        $response = $document->getMetaResponse(
+        $content = $document->getMetaContent(
             $request,
-            new Response(),
             new DefaultExceptionFactory(),
-            new DefaultSerializer(),
-            [],
-            $responseCode
+            []
         );
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals($meta, $this->getContentFromResponse("meta", $response));
+
+        $this->assertArrayNotHasKey('meta', $content);
     }
 
     /**
      * @test
      */
-    public function getMetaResponse()
+    public function getMetaContent()
     {
         $request = new Request(new ServerRequest(), new DefaultExceptionFactory());
         $meta = ["abc" => "def"];
 
         $document = $this->createDocument(null, $meta);
-        $response = $document->getMetaResponse(
+        $content = $document->getMetaContent(
             $request,
-            new Response(),
             new DefaultExceptionFactory(),
-            new DefaultSerializer(),
-            [],
-            200
+            []
         );
-        $this->assertEquals($meta, $this->getContentFromResponse("meta", $response));
+
+        $this->assertArrayHasKey('meta', $content);
+        $this->assertEquals($meta, $content['meta']);
     }
 
     /**
      * @test
      */
-    public function getEmptyDataResponse()
+    public function getEmptyDataContent()
     {
         $request = new Request(new ServerRequest(), new DefaultExceptionFactory());
         $data = new SingleResourceData();
 
         $document = $this->createDocument(null, [], null, $data);
-        $response = $document->getResponse(
+        $content = $document->getContent(
             $request,
-            new Response(),
             new DefaultExceptionFactory(),
-            new DefaultSerializer(),
-            [],
-            200
+            []
         );
-        $this->assertEmpty($this->getContentFromResponse("data", $response));
+
+        $this->assertArrayHasKey('data', $content);
+        $this->assertEmpty($content['data']);
     }
 
     /**
      * @test
      */
-    public function getResponseWithLinks()
+    public function getContentWithLinks()
     {
         $request = new Request(new ServerRequest(), new DefaultExceptionFactory());
         $links = new Links("http://example.com", ["self" => new Link("/users/1"), "related" => new Link("/people/1")]);
 
         $document = $this->createDocument(null, [], $links);
-        $response = $document->getResponse(
+        $content = $document->getContent(
             $request,
-            new Response(),
             new DefaultExceptionFactory(),
-            new DefaultSerializer(),
-            [],
-            200
+            []
         );
-        $this->assertCount(2, $this->getContentFromResponse("links", $response));
+
+        $this->assertArrayHasKey('links', $content);
+        $this->assertCount(2, $content['links']);
     }
 
     /**
      * @test
      */
-    public function getEmptyDataResponseWithEmptyIncludes()
+    public function getEmptyDataContentWithEmptyIncludes()
     {
         $request = new Request(new ServerRequest(), new DefaultExceptionFactory());
         $data = null;
 
         $document = $this->createDocument(null, [], null, $data);
-        $response = $document->getResponse(
+        $content = $document->getContent(
             $request,
-            new Response(),
             new DefaultExceptionFactory(),
-            new DefaultSerializer(),
-            [],
-            200
+            []
         );
-        $this->assertEquals([], $this->getContentFromResponse("included", $response));
+
+        $this->assertArrayNotHasKey('included', $content);
     }
 
     /**
      * @test
      */
-    public function getEmptyDataResponseWithIncludes()
+    public function getEmptyDataContentWithIncludes()
     {
         $request = new Request(new ServerRequest(), new DefaultExceptionFactory());
         $data = new SingleResourceData();
@@ -163,48 +152,46 @@ class AbstractSuccessfulDocumentTest extends TestCase
         );
 
         $document = $this->createDocument(null, [], null, $data);
-        $response = $document->getResponse(
+        $content = $document->getContent(
             $request,
-            new Response(),
             new DefaultExceptionFactory(),
-            new DefaultSerializer(),
-            [],
-            200
+            []
         );
-        $this->assertEquals($data->transformIncludedResources(), $this->getContentFromResponse("included", $response));
+
+        $this->assertArrayHasKey('included', $content);
+        $this->assertEquals($data->transformIncludedResources(), $content['included']);
     }
 
     /**
      * @test
      */
-    public function getRelationshipResponse()
+    public function getRelationshipContent()
     {
         $request = new Request(new ServerRequest(), new DefaultExceptionFactory());
-        $relationshipResponseContentData = [
+        $relationshipContent = [
             "type" => "user",
             "id" => "1"
         ];
-        $relationshipResponseContent = [
-            "data" => $relationshipResponseContentData
+        $relationshipContentData = [
+            "data" => $relationshipContent
         ];
 
-        $document = $this->createDocument(null, [], null, null, $relationshipResponseContent);
-        $response = $document->getRelationshipResponse(
+        $document = $this->createDocument(null, [], null, null, $relationshipContentData);
+        $content = $document->getRelationship(
             "",
             $request,
-            new Response(),
             new DefaultExceptionFactory(),
-            new DefaultSerializer(),
-            [],
-            200
+            []
         );
-        $this->assertEquals($relationshipResponseContentData, $this->getContentFromResponse("data", $response));
+
+        $this->assertArrayHasKey('data', $content);
+        $this->assertEquals($relationshipContent, $content['data']);
     }
 
     /**
      * @test
      */
-    public function getRelationshipResponseWithIncluded()
+    public function getRelationshipWithIncluded()
     {
         $request = new Request(new ServerRequest(), new DefaultExceptionFactory());
         $data = new SingleResourceData();
@@ -222,28 +209,15 @@ class AbstractSuccessfulDocumentTest extends TestCase
         );
 
         $document = $this->createDocument(null, [], null, $data, []);
-        $response = $document->getRelationshipResponse(
+        $content = $document->getRelationship(
             "",
             $request,
-            new Response(),
             new DefaultExceptionFactory(),
-            new DefaultSerializer(),
-            [],
-            200
+            []
         );
-        $this->assertEquals($data->transformIncludedResources(), $this->getContentFromResponse("included", $response));
-    }
 
-    /**
-     * @param string $key
-     * @param \Psr\Http\Message\ResponseInterface $response
-     * @return array
-     */
-    private function getContentFromResponse($key, ResponseInterface $response)
-    {
-        $result = json_decode($response->getBody(), true);
-
-        return isset($result[$key]) ? $result[$key] : [];
+        $this->assertArrayHasKey('included', $content);
+        $this->assertEquals($data->transformIncludedResources(), $content['included']);
     }
 
     /**


### PR DESCRIPTION
This PR is to illustrate what I try to explain in #53 

As you can see, everything work like before, the main `JsonApi` class is always able to return PSR7 Response and the document is not reponsible anymore to generate it. The reponder use the serializer to do it.

What is missing : 

- do the same thing for errors.

WDYT ?