### PR TITLE
Fixed datatime format method from sql without second argument

### DIFF
--- a/src/TransformerTrait.php
+++ b/src/TransformerTrait.php
@@ -75,11 +75,15 @@ trait TransformerTrait
      */
     public function fromSqlToIso8601Time($string, $timeZoneName = "")
     {
-        return DateTime::createFromFormat(
-            "Y-m-d H:i:s",
-            $string,
-            $timeZoneName ? new \DateTimeZone($timeZoneName) : null
-        )->format(DateTime::ATOM);
+        $format = "Y-m-d H:i:s";
+
+        if ($timeZoneName) {
+            $date = DateTime::createFromFormat($format, $string, new \DateTimeZone($timeZoneName));
+        } else {
+            $date = DateTime::createFromFormat($format, $string);
+        }
+
+        return $date->format(DateTime::ATOM);
     }
 
     /**

--- a/tests/TransformerTraitTest.php
+++ b/tests/TransformerTraitTest.php
@@ -6,6 +6,18 @@ use WoohooLabs\Yin\TransformerTrait;
 
 class TransformerTraitTest extends TestCase
 {
+    private $defaultTimezone;
+
+    protected function setUp()
+    {
+        $this->defaultTimezone = date_default_timezone_get();
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->defaultTimezone);
+    }
+
     /**
      * @test
      */
@@ -83,6 +95,21 @@ class TransformerTraitTest extends TestCase
         $this->assertEquals(
             "2015-06-30T16:00:00+02:00",
             $transformerTrait->fromSqlToIso8601Time("2015-06-30 16:00:00", "Europe/Budapest")
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function transformFromSqlToIso8601TimeWithoutSecondArgument()
+    {
+        $transformerTrait = $this->createTransformerTrait();
+
+        date_default_timezone_set('Europe/Budapest');
+
+        $this->assertEquals(
+            "2015-06-30T16:00:00+02:00",
+            $transformerTrait->fromSqlToIso8601Time("2015-06-30 16:00:00")
         );
     }
 


### PR DESCRIPTION
For PHP-5.6 `DateTime::createFromFormat` does not accept null as second argument [[ref]][0].

[0]: https://travis-ci.org/alquerci/yin/builds/206115333