### PR TITLE
fix problem No 'Access-Control-Allow-Origin' header is present on the…

### DIFF
--- a/examples/index.php
+++ b/examples/index.php
@@ -105,6 +105,7 @@ function findRoute(Request $request, array $routes): Request
             $pattern
         );
         if (preg_match("#^$pattern/{0,1}$#", $requestLine, $matches) === 1) {
+            header('Access-Control-Allow-Origin: *');
             return $route($request, $matches);
         }
     }

--- a/examples/index.php
+++ b/examples/index.php
@@ -81,6 +81,7 @@ $request = findRoute($request, $routes);
 $jsonApi = new JsonApi($request, new Response(), $exceptionFactory);
 $action = $request->getAttribute("action");
 $response = call_user_func(new $action(), $jsonApi);
+$response = $response->withHeader("Access-Control-Allow-Origin", "*");
 
 // Emitting the response
 $emitter = new SapiEmitter();
@@ -105,7 +106,6 @@ function findRoute(Request $request, array $routes): Request
             $pattern
         );
         if (preg_match("#^$pattern/{0,1}$#", $requestLine, $matches) === 1) {
-            header('Access-Control-Allow-Origin: *');
             return $route($request, $matches);
         }
     }


### PR DESCRIPTION
If we use examples, project never send CORS header. This is usefull when request data with AJAX.

With this fix, examples can access with, for example, [ts-angular-jsonapi](https://github.com/reyesoft/ts-angular-jsonapi)

![error-cors](https://user-images.githubusercontent.com/938894/27988721-9163ed80-63ff-11e7-8370-367df290af1a.png)
