### PR TITLE
Resource types now accomplish the jsonapi specification

### DIFF
--- a/examples/Book/Action/GetBooksAction.php
+++ b/examples/Book/Action/GetBooksAction.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace WoohooLabs\Yin\Examples\Book\Action;
+
+use Psr\Http\Message\ResponseInterface;
+use WoohooLabs\Yin\Examples\Book\JsonApi\Document\BooksDocument;
+use WoohooLabs\Yin\Examples\Book\JsonApi\Resource\AuthorResourceTransformer;
+use WoohooLabs\Yin\Examples\Book\JsonApi\Resource\BookResourceTransformer;
+use WoohooLabs\Yin\Examples\Book\JsonApi\Resource\PublisherResourceTransformer;
+use WoohooLabs\Yin\Examples\Book\JsonApi\Resource\RepresentativeResourceTransformer;
+use WoohooLabs\Yin\Examples\Book\Repository\BookRepository;
+use WoohooLabs\Yin\JsonApi\JsonApi;
+
+class GetBooksAction
+{
+    public function __invoke(JsonApi $jsonApi): ResponseInterface
+    {
+        // Extracting pagination information from the request, page = 1, size = 10 if it is missing
+        $pagination = $jsonApi->getRequest()->getPageBasedPagination(1, 10);
+
+        // Retrieving a paginated collection of Book domain objects
+        $books = BookRepository::getBooks($pagination->getPage(), $pagination->getSize());
+
+        // Instantiating a Books document
+        $document = new BooksDocument(
+            new BookResourceTransformer(
+                new AuthorResourceTransformer(),
+                new PublisherResourceTransformer(
+                    new RepresentativeResourceTransformer()
+                )
+            )
+        );
+
+        // Responding with "200 Ok" status code along with the Books document
+        return $jsonApi->respond()->ok($document, $books);
+    }
+}

--- a/examples/Book/JsonApi/Document/BooksDocument.php
+++ b/examples/Book/JsonApi/Document/BooksDocument.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+namespace WoohooLabs\Yin\Examples\Book\JsonApi\Document;
+
+use WoohooLabs\Yin\Examples\Book\JsonApi\Resource\BookResourceTransformer;
+use WoohooLabs\Yin\JsonApi\Document\AbstractCollectionDocument;
+use WoohooLabs\Yin\JsonApi\Schema\JsonApiObject;
+use WoohooLabs\Yin\JsonApi\Schema\Links;
+
+class BooksDocument extends AbstractCollectionDocument
+{
+    public function __construct(BookResourceTransformer $transformer)
+    {
+        parent::__construct($transformer);
+    }
+
+    /**
+     * Provides information about the "jsonapi" member of the current document.
+     *
+     * The method returns a new JsonApiObject schema object if this member should be present or null
+     * if it should be omitted from the response.
+     *
+     * @return JsonApiObject|null
+     */
+    public function getJsonApi()
+    {
+        return null;
+    }
+
+    /**
+     * Provides information about the "meta" member of the current document.
+     *
+     * The method returns an array of non-standard meta information about the document. If
+     * this array is empty, the member won't appear in the response.
+     */
+    public function getMeta(): array
+    {
+        return [];
+    }
+
+    /**
+     * Provides information about the "links" member of the current document.
+     *
+     * The method returns a new Links schema object if you want to provide linkage data
+     * for the document or null if the section should be omitted from the response.
+     *
+     * @return Links|null
+     */
+    public function getLinks()
+    {
+        return Links::createWithoutBaseUri()->setPagination("/?path=/books", $this->domainObject);
+    }
+}

--- a/examples/Book/JsonApi/Resource/AuthorResourceTransformer.php
+++ b/examples/Book/JsonApi/Resource/AuthorResourceTransformer.php
@@ -18,7 +18,7 @@ class AuthorResourceTransformer extends AbstractResourceTransformer
      */
     public function getType($author) : string
     {
-        return "author";
+        return "authors";
     }
 
     /**

--- a/examples/Book/JsonApi/Resource/BookResourceTransformer.php
+++ b/examples/Book/JsonApi/Resource/BookResourceTransformer.php
@@ -38,7 +38,7 @@ class BookResourceTransformer extends AbstractResourceTransformer
      */
     public function getType($book): string
     {
-        return "book";
+        return "books";
     }
 
     /**

--- a/examples/Book/JsonApi/Resource/PublisherResourceTransformer.php
+++ b/examples/Book/JsonApi/Resource/PublisherResourceTransformer.php
@@ -28,7 +28,7 @@ class PublisherResourceTransformer extends AbstractResourceTransformer
      */
     public function getType($publisher): string
     {
-        return "publisher";
+        return "publishers";
     }
 
     /**

--- a/examples/Book/JsonApi/Resource/RepresentativeResourceTransformer.php
+++ b/examples/Book/JsonApi/Resource/RepresentativeResourceTransformer.php
@@ -17,7 +17,7 @@ class RepresentativeResourceTransformer extends AbstractResourceTransformer
      */
     public function getType($representative): string
     {
-        return "representative";
+        return "representatives";
     }
 
     /**

--- a/examples/Book/Repository/BookRepository.php
+++ b/examples/Book/Repository/BookRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace WoohooLabs\Yin\Examples\Book\Repository;
 
 use WoohooLabs\Yin\Examples\Utils\AbstractRepository;
+use WoohooLabs\Yin\Examples\Utils\Collection;
 
 class BookRepository extends AbstractRepository
 {
@@ -55,6 +56,25 @@ class BookRepository extends AbstractRepository
             "publisher" => "12346"
         ]
     ];
+
+    public static function getBooks(int $page = null, int $size = null): Collection
+    {
+        if ($page === null) {
+            $page = 1;
+        }
+
+        if ($size === null) {
+            $size = 10;
+        }
+
+        $books = array_slice(self::$books, ($page - 1) * $size, $size);
+
+        foreach ($books as $key => $book) {
+            $books[$key]["authors"] = self::getItemsByIds($book["authors"], self::$authors);
+        }
+
+        return new Collection($books, count(self::$books), $page, $size);
+    }
 
     /**
      * @return array|null

--- a/examples/User/JsonApi/Resource/ContactResourceTransformer.php
+++ b/examples/User/JsonApi/Resource/ContactResourceTransformer.php
@@ -18,7 +18,7 @@ class ContactResourceTransformer extends AbstractResourceTransformer
      */
     public function getType($contact): string
     {
-        return "contact";
+        return "contacts";
     }
 
     /**

--- a/examples/User/JsonApi/Resource/UserResourceTransformer.php
+++ b/examples/User/JsonApi/Resource/UserResourceTransformer.php
@@ -29,7 +29,7 @@ class UserResourceTransformer extends AbstractResourceTransformer
      */
     public function getType($user): string
     {
-        return "user";
+        return "users";
     }
 
     /**

--- a/examples/index.php
+++ b/examples/index.php
@@ -7,6 +7,7 @@ use WoohooLabs\Yin\Examples\Book\Action\CreateBookAction;
 use WoohooLabs\Yin\Examples\Book\Action\GetAuthorsOfBookAction;
 use WoohooLabs\Yin\Examples\Book\Action\GetBookAction;
 use WoohooLabs\Yin\Examples\Book\Action\GetBookRelationshipsAction;
+use WoohooLabs\Yin\Examples\Book\Action\GetBooksAction;
 use WoohooLabs\Yin\Examples\Book\Action\UpdateBookAction;
 use WoohooLabs\Yin\Examples\Book\Action\UpdateBookRelationshipAction;
 use WoohooLabs\Yin\Examples\User\Action\GetUserAction;
@@ -22,6 +23,10 @@ use Zend\Diactoros\ServerRequestFactory;
 
 // Defining routes
 $routes = [
+    "GET /books" => function (Request $request): Request {
+        return $request
+            ->withAttribute("action", GetBooksAction::class);
+    },
     "GET /books/{id}" => function (Request $request, array $matches): Request {
         return $request
             ->withAttribute("action", GetBookAction::class)
@@ -81,6 +86,7 @@ $request = findRoute($request, $routes);
 $jsonApi = new JsonApi($request, new Response(), $exceptionFactory);
 $action = $request->getAttribute("action");
 $response = call_user_func(new $action(), $jsonApi);
+$response = $response->withHeader("Access-Control-Allow-Origin", "*");
 
 // Emitting the response
 $emitter = new SapiEmitter();


### PR DESCRIPTION
## Problem

YIM examples return resource types in singular, but path is in plural.

## Recomendation and fix

Although the [examples of the official site resources are in the plural](http://jsonapi.org/format/#document-resource-objects), they can also be in the singular.

But, according to the specification:

> This spec is agnostic about inflection rules, so the value of type can be either plural or singular. However, the same value should be used consistently throughout an implementation.

With this PR, `type` and `paths` are the same string for the same type resource.