### PR TITLE
Fixed invalid resource id

### DIFF
--- a/src/JsonApi/Exception/ResourceIdInvalid.php
+++ b/src/JsonApi/Exception/ResourceIdInvalid.php
@@ -13,7 +13,7 @@ class ResourceIdInvalid extends JsonApiException
      */
     protected $id;
 
-    public function __construct(string $id)
+    public function __construct($id)
     {
         parent::__construct("The resource ID '$id' must be a string!");
         $this->id = $id;

--- a/tests/JsonApi/Exception/ResourceIdInvalidTest.php
+++ b/tests/JsonApi/Exception/ResourceIdInvalidTest.php
@@ -19,7 +19,18 @@ class ResourceIdInvalidTest extends TestCase
         $this->assertEquals($id, $exception->getId());
     }
 
-    private function createException(string $id): ResourceIdInvalid
+    /**
+     * @test
+     */
+    public function createExceptionForNotString()
+    {
+        $id = 1;
+
+        $exception = $this->createException($id);
+        $this->assertEquals($id, $exception->getId());
+    }
+
+    private function createException($id): ResourceIdInvalid
     {
         return new ResourceIdInvalid($id);
     }


### PR DESCRIPTION
Hello everyone,

I submit a small for an error I found.

When an user submits a request with an ID which is not string, he receives PHP type error instead of exception.

For example
```
PATCH /api/v1/sometypes/1 HTTP/1.1
Content-Type: application/json

{
  "data": {
    "type": "sometypes",
    "id": 1,
    "attributes": {
      "foo": "bar"
    }
  }
}
```

Actual error:
```
Type error: Argument 1 passed to WoohooLabs\Yin\JsonApi\Exception\ResourceIdInvalid::__construct() must be of the type string, integer given
```

Expected exception:
```
WoohooLabs\Yin\JsonApi\Exception\ResourceIdInvalid: The resource ID '1' must be a string!
```

Best regards,
Piotr Belina