### PR TITLE
Fixed invalid sort value type error

### DIFF
--- a/src/JsonApi/Exception/DefaultExceptionFactory.php
+++ b/src/JsonApi/Exception/DefaultExceptionFactory.php
@@ -75,6 +75,14 @@ class DefaultExceptionFactory implements ExceptionFactoryInterface
         return new QueryParamUnrecognized($queryParamName);
     }
 
+    public function createQueryParamMalformedException(
+        RequestInterface $request,
+        string $queryParamName,
+        $queryParamValue
+    ): QueryParamMalformed {
+        return new QueryParamMalformed($queryParamName, $queryParamValue);
+    }
+
     public function createRelationshipNotExistsException(string $relationship): RelationshipNotExists
     {
         return new RelationshipNotExists($relationship);

--- a/src/JsonApi/Exception/ExceptionFactoryInterface.php
+++ b/src/JsonApi/Exception/ExceptionFactoryInterface.php
@@ -67,6 +67,11 @@ interface ExceptionFactoryInterface
     /**
      * @return JsonApiExceptionInterface|Exception
      */
+    public function createQueryParamMalformedException(RequestInterface $request, string $queryParamName, $queryParamValue);
+
+    /**
+     * @return JsonApiExceptionInterface|Exception
+     */
     public function createRelationshipNotExistsException(string $relationship);
 
     /**

--- a/src/JsonApi/Exception/QueryParamMalformed.php
+++ b/src/JsonApi/Exception/QueryParamMalformed.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+namespace WoohooLabs\Yin\JsonApi\Exception;
+
+use WoohooLabs\Yin\JsonApi\Schema\Error;
+use WoohooLabs\Yin\JsonApi\Schema\ErrorSource;
+
+class QueryParamMalformed extends JsonApiException
+{
+    /**
+     * @var string
+     */
+    protected $malformedQueryParam;
+
+    /**
+     * @var mixed
+     */
+    protected $malformedQueryParamValue;
+
+    /**
+     * QueryParamMalformed constructor.
+     * @param string $malformedQueryParam
+     * @param mixed $malformedQueryParamValue
+     */
+    public function __construct(string $malformedQueryParam, $malformedQueryParamValue)
+    {
+        parent::__construct("Query parameter '$malformedQueryParam' is malformed!");
+        $this->malformedQueryParam = $malformedQueryParam;
+        $this->malformedQueryParamValue = $malformedQueryParamValue;
+    }
+
+    protected function getErrors(): array
+    {
+        return [
+            Error::create()
+                ->setStatus("400")
+                ->setCode("QUERY_PARAM_MALFORMED")
+                ->setTitle("Query parameter is malformed")
+                ->setDetail("Query parameter '$this->malformedQueryParam' is malformed!")
+                ->setSource(ErrorSource::fromParameter($this->malformedQueryParam))
+        ];
+    }
+
+    public function getMalformedQueryParam(): string
+    {
+        return $this->malformedQueryParam;
+    }
+
+    public function getMalformedQueryParamValue()
+    {
+        return $this->malformedQueryParamValue;
+    }
+}

--- a/src/JsonApi/Request/Request.php
+++ b/src/JsonApi/Request/Request.php
@@ -10,6 +10,7 @@ use Psr\Http\Message\UriInterface;
 use WoohooLabs\Yin\JsonApi\Exception\ExceptionFactoryInterface;
 use WoohooLabs\Yin\JsonApi\Exception\MediaTypeUnacceptable;
 use WoohooLabs\Yin\JsonApi\Exception\MediaTypeUnsupported;
+use WoohooLabs\Yin\JsonApi\Exception\QueryParamMalformed;
 use WoohooLabs\Yin\JsonApi\Exception\QueryParamUnrecognized;
 use WoohooLabs\Yin\JsonApi\Hydrator\Relationship\ToManyRelationship;
 use WoohooLabs\Yin\JsonApi\Hydrator\Relationship\ToOneRelationship;
@@ -278,8 +279,12 @@ class Request implements RequestInterface
     protected function setSorting()
     {
         $sortingQueryParam = $this->getQueryParam("sort", "");
+        if (!is_string($sortingQueryParam)) {
+            throw $this->exceptionFactory->createQueryParamMalformedException($this, "sort", $sortingQueryParam);
+        }
         if ($sortingQueryParam === "") {
             $this->sorting = [];
+
             return;
         }
 

--- a/tests/JsonApi/Exception/QueryParamMalformedTest.php
+++ b/tests/JsonApi/Exception/QueryParamMalformedTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace WoohooLabs\Yin\Tests\JsonApi\Exception;
+
+use PHPUnit\Framework\TestCase;
+use WoohooLabs\Yin\JsonApi\Exception\QueryParamMalformed;
+
+class QueryParamMalformedTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function getQueryParam()
+    {
+        $queryParam = "sort";
+        $queryParamValue = ["field" => "asc"];
+
+        $exception = $this->createException($queryParam, $queryParamValue);
+        $this->assertEquals($queryParam, $exception->getMalformedQueryParam());
+        $this->assertEquals($queryParamValue, $exception->getMalformedQueryParamValue());
+    }
+
+    private function createException($queryParam, $queryParamValue): QueryParamMalformed
+    {
+        return new QueryParamMalformed($queryParam, $queryParamValue);
+    }
+}

--- a/tests/JsonApi/Request/RequestTest.php
+++ b/tests/JsonApi/Request/RequestTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use WoohooLabs\Yin\JsonApi\Exception\DefaultExceptionFactory;
 use WoohooLabs\Yin\JsonApi\Exception\MediaTypeUnacceptable;
 use WoohooLabs\Yin\JsonApi\Exception\MediaTypeUnsupported;
+use WoohooLabs\Yin\JsonApi\Exception\QueryParamMalformed;
 use WoohooLabs\Yin\JsonApi\Exception\QueryParamUnrecognized;
 use WoohooLabs\Yin\JsonApi\Request\Pagination\CursorBasedPagination;
 use WoohooLabs\Yin\JsonApi\Request\Pagination\FixedPageBasedPagination;
@@ -415,6 +416,19 @@ class RequestTest extends TestCase
 
         $request = $this->createRequestWithQueryParams($queryParams);
         $this->assertEquals($sorting, $request->getSorting());
+    }
+
+    /**
+     * @test
+     */
+    public function getSortingWhenMalformed()
+    {
+        $this->expectException(QueryParamMalformed::class);
+
+        $queryParams = ["sort" => ["name" => "asc"]];
+
+        $request = $this->createRequestWithQueryParams($queryParams);
+        $request->getSorting();
     }
 
     /**


### PR DESCRIPTION
Hello Máté,

I'm sending a fix for invalid sort attribute value.

For example
```
GET /api/v1/foo?sort[company_id]=asc
```

Actual error:
```
Type error: explode() expects parameter 2 to be string, array given on /vendor/woohoolabs/yin/src/JsonApi/Request/Request.php line 286
```

Expected some 400 exception

Cheers,
Piotr