### PR TITLE
Fix output for ToOneRelationship

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ vendor/
 composer.lock
 phpunit.xml
 .env
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 composer.lock
 phpunit.xml
 .env
+.idea

--- a/src/JsonApi/Schema/Relationship/AbstractRelationship.php
+++ b/src/JsonApi/Schema/Relationship/AbstractRelationship.php
@@ -135,8 +135,7 @@ abstract class AbstractRelationship
             "data" => null,
         ];
         
-        if (
-            (
+        if ((
                 $transformation->fetchedRelationship === $relationshipName &&
                 $this->data !== null &&
                 $this->omitDataWhenNotIncluded === false
@@ -153,7 +152,6 @@ abstract class AbstractRelationship
         }
 
         if ($transformation->request->isIncludedField($resourceType, $relationshipName)) {
-
             // Links
             if ($this->links !== null) {
                 $relationship["links"] = $this->links->transform();

--- a/src/JsonApi/Schema/Relationship/AbstractRelationship.php
+++ b/src/JsonApi/Schema/Relationship/AbstractRelationship.php
@@ -131,12 +131,14 @@ abstract class AbstractRelationship
         array $defaultRelationships,
         array $additionalMeta = []
     ): ?array {
-        $relationship = null;
-
+        $relationship = [
+            "data" => null,
+        ];
+        
         if (
             (
                 $transformation->fetchedRelationship === $relationshipName &&
-                $this->data &&
+                $this->data !== null &&
                 $this->omitDataWhenNotIncluded === false
             ) ||
             $transformation->request->isIncludedRelationship(
@@ -151,7 +153,6 @@ abstract class AbstractRelationship
         }
 
         if ($transformation->request->isIncludedField($resourceType, $relationshipName)) {
-            $relationship = [];
 
             // Links
             if ($this->links !== null) {

--- a/tests/JsonApi/Schema/Relationship/AbstractRelationshipTest.php
+++ b/tests/JsonApi/Schema/Relationship/AbstractRelationshipTest.php
@@ -83,6 +83,7 @@ class AbstractRelationshipTest extends TestCase
         );
         $this->assertEquals(
             [
+                "data" => null,
             ],
             $result
         );

--- a/tests/JsonApi/Transformer/AbstractResourceTransformerTest.php
+++ b/tests/JsonApi/Transformer/AbstractResourceTransformerTest.php
@@ -12,6 +12,7 @@ use WoohooLabs\Yin\JsonApi\Schema\Data\DataInterface;
 use WoohooLabs\Yin\JsonApi\Schema\Data\SingleResourceData;
 use WoohooLabs\Yin\JsonApi\Schema\Link\Link;
 use WoohooLabs\Yin\JsonApi\Schema\Links;
+use WoohooLabs\Yin\JsonApi\Schema\Relationship\ToManyRelationship;
 use WoohooLabs\Yin\JsonApi\Schema\Relationship\ToOneRelationship;
 use WoohooLabs\Yin\JsonApi\Schema\Resource\AbstractResource;
 use WoohooLabs\Yin\JsonApi\Serializer\JsonDeserializer;
@@ -263,6 +264,53 @@ class AbstractResourceTransformerTest extends TestCase
         $transformedResource = $transformer->transformRelationship("father", $transformation, []);
         $this->assertEquals("user", $transformedResource["data"]["type"]);
         $this->assertEquals("2", $transformedResource["data"]["id"]);
+    }
+    /**
+     * @test
+     */
+    public function transformToManyRelationship()
+    {
+        $defaultRelationships = ["father"];
+        $relationships = [
+            "father" => function () {
+                $relationship = new ToManyRelationship();
+                $relationship->setData([
+                    ["Father Vader"],
+                ], new StubResourceTransformer("user", "2"));
+                return $relationship;
+            }
+        ];
+    
+        $request = new StubRequest();
+        $data = new SingleResourceData();
+        $transformer = $this->createTransformer("user", "1", [], null, [], $defaultRelationships, $relationships);
+        $transformation = new Transformation($request, $data, new DefaultExceptionFactory(), "");
+        $transformedResource = $transformer->transformRelationship("father", $transformation, []);
+        $transformedResourceData = $transformedResource["data"];
+        $this->assertEquals("user", $transformedResourceData[0]["type"]);
+        $this->assertEquals("2", $transformedResourceData[0]["id"]);
+    }
+    /**
+     * @test
+     */
+    public function transformToManyEmptyRelationship()
+    {
+        $defaultRelationships = ["father"];
+        $relationships = [
+            "father" => function () {
+                $relationship = new ToManyRelationship();
+                return $relationship;
+            }
+        ];
+    
+        $request = new StubRequest();
+        $data = new SingleResourceData();
+        $transformer = $this->createTransformer("user", "1", [], null, [], $defaultRelationships, $relationships);
+        $transformation = new Transformation($request, $data, new DefaultExceptionFactory(), "");
+        $transformedResource = $transformer->transformRelationship("father", $transformation, []);
+        $this->assertEquals([
+            "data" => [],
+        ], $transformedResource);
     }
 
     /**


### PR DESCRIPTION
As per [json:api docs](https://jsonapi.org/format/#document-resource-object-linkage) resource linkage data must be either null in case of single relation or empty array in case of many relation.
In case of ToManyRelatioship it was ok but in case of ToOneRelationship it was not so we fixed it
This is how it outputs in the current version:
```
"relationships": {
    "one": []
    "many: {
         "data": []
    }
}
```
And this is how it outputs in the fix:
```
"relationships": {
    "one": {
         "data": null
    }
    "many: {
         "data": []
    }
}
```

We also added tests for ToManyRelationship in AbstractResourceTransformerTest file:
1. case when many relationship is empty
2. case when many relationship has one entry 
