### PR TITLE
Make addLink accessor public

### DIFF
--- a/src/JsonApi/Schema/Link/AbstractLinks.php
+++ b/src/JsonApi/Schema/Link/AbstractLinks.php
@@ -53,6 +53,29 @@ abstract class AbstractLinks
         return $links;
     }
 
+    /**
+     * @param Link[] $links
+     * @return static
+     */
+    public function setLinks(array $links)
+    {
+        foreach ($links as $rel => $link) {
+            $this->addLink($rel, $link);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return static
+     */
+    public function setLink(string $name, ?Link $link)
+    {
+        $this->addLink($name, $link);
+
+        return $this;
+    }
+
     protected function addLink(string $name, ?Link $link): void
     {
         $this->links[$name] = $link;

--- a/src/JsonApi/Schema/Link/DocumentLinks.php
+++ b/src/JsonApi/Schema/Link/DocumentLinks.php
@@ -147,23 +147,4 @@ class DocumentLinks extends AbstractLinks
 
         return $this;
     }
-
-    /**
-     * @param Link[] $links
-     */
-    public function setLinks(array $links): DocumentLinks
-    {
-        foreach ($links as $rel => $link) {
-            $this->addLink($rel, $link);
-        }
-
-        return $this;
-    }
-
-    public function setLink(string $name, ?Link $link): DocumentLinks
-    {
-        $this->addLink($name, $link);
-
-        return $this;
-    }
 }


### PR DESCRIPTION
When customizing the links of a document it is rather challenging to have the `addLink` method not publicly available. This PR fixes that.