### PR TITLE
Fix array_merge increment problems

### DIFF
--- a/src/JsonApi/Transformer/DocumentTransformer.php
+++ b/src/JsonApi/Transformer/DocumentTransformer.php
@@ -6,8 +6,6 @@ namespace WoohooLabs\Yin\JsonApi\Transformer;
 
 use WoohooLabs\Yin\JsonApi\Schema\Data\SingleResourceData;
 
-use function array_merge;
-
 /**
  * @internal
  */

--- a/src/JsonApi/Transformer/DocumentTransformer.php
+++ b/src/JsonApi/Transformer/DocumentTransformer.php
@@ -74,8 +74,12 @@ final class DocumentTransformer
             $transformation->result["jsonapi"] = $jsonApi->transform();
         }
 
-        $meta = array_merge($transformation->document->getMeta(), $transformation->additionalMeta);
-        if (empty($meta) === false) {
+        $meta = $transformation->document->getMeta();
+        foreach ($transformation->additionalMeta as $metaKey => $metaValue) {
+            $meta[$metaKey] = $metaValue;
+        }
+
+        if (!empty($meta)) {
             $transformation->result["meta"] = $meta;
         }
 


### PR DESCRIPTION
Document transformer transformMetaMembers() will reset array keys to increment value / integer when meta contains numeric float|int|number(int)string offset.

https://github.com/woohoolabs/yin/issues/108